### PR TITLE
Temporarily disable react-snap to allow builds to proceed

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "postbuild": "react-snap"
+    "snap-build": "react-snap"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
`react-snap` is breaking the build process on GitHub actions - my guess is some rendering loop. So, in the meantime, let's disable it and diagnose it later.